### PR TITLE
refactor: remove injuries

### DIFF
--- a/client/damage/damage-effects.lua
+++ b/client/damage/damage-effects.lua
@@ -3,11 +3,11 @@ local armCount = 0
 local headCount = 0
 
 ---based off of injuries to leg bodyparts of a certain severity.
----@param part BodyPartKey
----@param injury Injury
+---@param bodyPartKey BodyPartKey
+---@param bodyPart BodyPart
 ---@return boolean isLegDamaged if leg is considered damaged
-local function isLegDamaged(part, injury)
-    return (part == 'LLEG' and injury.severity > 1) or (part == 'RLEG' and injury.severity > 1) or (part == 'LFOOT' and injury.severity > 2) or (part == 'RFOOT' and injury.severity > 2)
+local function isLegDamaged(bodyPartKey, bodyPart)
+    return (bodyPartKey == 'LLEG' and bodyPart.severity > 1) or (bodyPartKey == 'RLEG' and bodyPart.severity > 1) or (bodyPartKey == 'LFOOT' and bodyPart.severity > 2) or (bodyPartKey == 'RFOOT' and bodyPart.severity > 2)
 end
 
 ---shake camera and ragdoll player forward
@@ -28,19 +28,19 @@ local function chancePedFalls(ped)
 end
 
 ---checks if left arm is damaged based off of injury location and severity.
----@param part BodyPartKey
----@param injury Injury
+---@param bodyPartKey BodyPartKey
+---@param bodyPart BodyPart
 ---@return boolean isDamaged true if the left arm is damaged
-local function isLeftArmDamaged(part, injury)
-    return (part == 'LARM' and injury.severity > 1) or (part == 'LHAND' and injury.severity > 1) or (part == 'LFINGER' and injury.severity > 2)
+local function isLeftArmDamaged(bodyPartKey, bodyPart)
+    return (bodyPartKey == 'LARM' and bodyPart.severity > 1) or (bodyPartKey == 'LHAND' and bodyPart.severity > 1) or (bodyPartKey == 'LFINGER' and bodyPart.severity > 2)
 end
 
 ---checks if either arm is damaged based on injury location and severity.
----@param part BodyPartKey
----@param injury Injury
+---@param bodyPartKey BodyPartKey
+---@param bodyPart BodyPart
 ---@return boolean isDamaged true if either arm is damaged
-local function isArmDamaged(part, injury)
-    return isLeftArmDamaged(part, injury) or (part == 'RARM' and injury.severity > 1) or (part == 'RHAND' and injury.severity > 1) or (part == 'RFINGER' and injury.severity > 2)
+local function isArmDamaged(bodyPartKey, bodyPart)
+    return isLeftArmDamaged(bodyPartKey, bodyPart) or (bodyPartKey == 'RARM' and bodyPart.severity > 1) or (bodyPartKey == 'RHAND' and bodyPart.severity > 1) or (bodyPartKey == 'RFINGER' and bodyPart.severity > 2)
 end
 
 ---enforce following arm disabilities on the player for a set time period:
@@ -69,11 +69,11 @@ local function disableArms(ped, leftArmDamaged)
 end
 
 ---returns whether the player's head is damaged based on injury location and severity.
----@param part BodyPartKey
----@param injury Injury
+---@param bodyPartKey BodyPartKey
+---@param bodyPart BodyPart
 ---@return boolean
-local function isHeadDamaged(part, injury)
-    return part == 'HEAD' and injury.severity > 2
+local function isHeadDamaged(bodyPartKey, bodyPart)
+    return bodyPartKey == 'HEAD' and bodyPart.severity > 2
 end
 
 ---flash screen, fade out, ragdoll, fade in.
@@ -100,36 +100,32 @@ function ApplyDamageEffects()
     local ped = cache.ped
     if IsDead or InLaststand then return end
     for bodyPartKey, bodyPart in pairs(BodyParts) do
-        for i = 1, #bodyPart.injuries do
-            local injury = bodyPart.injuries[i]
+        if isLegDamaged(bodyPartKey, bodyPart) then
+            if legCount >= Config.LegInjuryTimer then
+                chancePedFalls(ped)
+                legCount = 0
+            else
+                legCount += 1
+            end
+        elseif isArmDamaged(bodyPartKey, bodyPart) then
+            if armCount >= Config.ArmInjuryTimer then
+                CreateThread(function()
+                    disableArms(ped, isLeftArmDamaged(bodyPartKey, bodyPart))
+                end)
+                armCount = 0
+            else
+                armCount += 1
+            end
+        elseif isHeadDamaged(bodyPartKey, bodyPart) then
+            if headCount >= Config.HeadInjuryTimer then
+                local chance = math.random(100)
 
-            if isLegDamaged(bodyPartKey, injury) then
-                if legCount >= Config.LegInjuryTimer then
-                    chancePedFalls(ped)
-                    legCount = 0
-                else
-                    legCount += 1
+                if chance <= Config.HeadInjuryChance then
+                    playBrainDamageEffectAndRagdoll(ped)
                 end
-            elseif isArmDamaged(bodyPartKey, injury) then
-                if armCount >= Config.ArmInjuryTimer then
-                    CreateThread(function()
-                        disableArms(ped, isLeftArmDamaged(bodyPartKey, injury))
-                    end)
-                    armCount = 0
-                else
-                    armCount += 1
-                end
-            elseif isHeadDamaged(bodyPartKey, injury) then
-                if headCount >= Config.HeadInjuryTimer then
-                    local chance = math.random(100)
-
-                    if chance <= Config.HeadInjuryChance then
-                        playBrainDamageEffectAndRagdoll(ped)
-                    end
-                    headCount = 0
-                else
-                    headCount += 1
-                end
+                headCount = 0
+            else
+                headCount += 1
             end
         end
     end

--- a/client/damage/damage.lua
+++ b/client/damage/damage.lua
@@ -8,9 +8,6 @@ local function upgradeInjury(bodyPart, bone)
 
     bodyPart.severity += 1
     DamageBodyPart(bone, bodyPart.severity)
-    for i = 1, #bodyPart.injuries do
-        bodyPart.injuries[i].severity = bodyPart.severity
-    end
 end
 
 ---create/upgrade injury at bone.

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,9 +1,6 @@
 ---@type number[] weapon hashes
 CurrentDamageList = {}
 
----@class Injury
----@field severity integer higher numbers are worse injuries
-
 NumInjuries = 0
 
 ---@class BodyPart
@@ -11,28 +8,27 @@ NumInjuries = 0
 ---@field causeLimp boolean
 ---@field isDamaged boolean
 ---@field severity integer
----@field injuries Injury[]
 
 ---@alias BodyPartKey string
 
 ---@alias BodyParts table<BodyPartKey, BodyPart>
 ---@type BodyParts
 BodyParts = {
-    HEAD = { label = Lang:t('body.head'), causeLimp = false, isDamaged = false, severity = 0, injuries = {} },
-    NECK = { label = Lang:t('body.neck'), causeLimp = false, isDamaged = false, severity = 0, injuries = {} },
-    SPINE = { label = Lang:t('body.spine'), causeLimp = true, isDamaged = false, severity = 0, injuries = {} },
-    UPPER_BODY = { label = Lang:t('body.upper_body'), causeLimp = false, isDamaged = false, severity = 0, injuries = {} },
-    LOWER_BODY = { label = Lang:t('body.lower_body'), causeLimp = true, isDamaged = false, severity = 0, injuries = {} },
-    LARM = { label = Lang:t('body.left_arm'), causeLimp = false, isDamaged = false, severity = 0, injuries = {} },
-    LHAND = { label = Lang:t('body.left_hand'), causeLimp = false, isDamaged = false, severity = 0, injuries = {} },
-    LFINGER = { label = Lang:t('body.left_fingers'), causeLimp = false, isDamaged = false, severity = 0, injuries = {} },
-    LLEG = { label = Lang:t('body.left_leg'), causeLimp = true, isDamaged = false, severity = 0, injuries = {} },
-    LFOOT = { label = Lang:t('body.left_foot'), causeLimp = true, isDamaged = false, severity = 0, injuries = {} },
-    RARM = { label = Lang:t('body.right_arm'), causeLimp = false, isDamaged = false, severity = 0, injuries = {} },
-    RHAND = { label = Lang:t('body.right_hand'), causeLimp = false, isDamaged = false, severity = 0, injuries = {} },
-    RFINGER = { label = Lang:t('body.right_fingers'), causeLimp = false, isDamaged = false, severity = 0, injuries = {} },
-    RLEG = { label = Lang:t('body.right_leg'), causeLimp = true, isDamaged = false, severity = 0, injuries = {} },
-    RFOOT = { label = Lang:t('body.right_foot'), causeLimp = true, isDamaged = false, severity = 0, injuries = {} },
+    HEAD = { label = Lang:t('body.head'), causeLimp = false, isDamaged = false, severity = 0 },
+    NECK = { label = Lang:t('body.neck'), causeLimp = false, isDamaged = false, severity = 0 },
+    SPINE = { label = Lang:t('body.spine'), causeLimp = true, isDamaged = false, severity = 0 },
+    UPPER_BODY = { label = Lang:t('body.upper_body'), causeLimp = false, isDamaged = false, severity = 0 },
+    LOWER_BODY = { label = Lang:t('body.lower_body'), causeLimp = true, isDamaged = false, severity = 0 },
+    LARM = { label = Lang:t('body.left_arm'), causeLimp = false, isDamaged = false, severity = 0, },
+    LHAND = { label = Lang:t('body.left_hand'), causeLimp = false, isDamaged = false, severity = 0, },
+    LFINGER = { label = Lang:t('body.left_fingers'), causeLimp = false, isDamaged = false, severity = 0, },
+    LLEG = { label = Lang:t('body.left_leg'), causeLimp = true, isDamaged = false, severity = 0, },
+    LFOOT = { label = Lang:t('body.left_foot'), causeLimp = true, isDamaged = false, severity = 0, },
+    RARM = { label = Lang:t('body.right_arm'), causeLimp = false, isDamaged = false, severity = 0, },
+    RHAND = { label = Lang:t('body.right_hand'), causeLimp = false, isDamaged = false, severity = 0, },
+    RFINGER = { label = Lang:t('body.right_fingers'), causeLimp = false, isDamaged = false, severity = 0, },
+    RLEG = { label = Lang:t('body.right_leg'), causeLimp = true, isDamaged = false, severity = 0, },
+    RFOOT = { label = Lang:t('body.right_foot'), causeLimp = true, isDamaged = false, severity = 0, },
 }
 
 BleedLevel = 0
@@ -124,9 +120,8 @@ local function doLimbAlert()
     if NumInjuries <= Config.AlertShowInfo then
         local injuriesI = 0
         for _, bodyPart in pairs(BodyParts) do
-            for i = 1, #bodyPart.injuries do
-                local injury = bodyPart.injuries[i]
-                limbDamageMsg = limbDamageMsg .. Lang:t('info.pain_message', { limb = bodyPart.label, severity = Config.woundLevels[injury.severity].label})
+            if bodyPart.severity > 0 then
+                limbDamageMsg = limbDamageMsg .. Lang:t('info.pain_message', { limb = bodyPart.label, severity = Config.woundLevels[bodyPart.severity].label})
                 injuriesI += 1
                 if injuriesI < NumInjuries then
                     limbDamageMsg = limbDamageMsg .. " | "
@@ -156,14 +151,6 @@ function ResetMinorInjuries()
             bodyPart.isDamaged = false
             bodyPart.severity = 0
         end
-        local onlySevereInjuries = {}
-        for i = 1, #bodyPart.injuries do
-            local injury = bodyPart.injuries[i]
-            if injury.severity > 2 then
-                onlySevereInjuries[#onlySevereInjuries+1] = injury
-            end
-        end
-        bodyPart.injuries = onlySevereInjuries
     end
 
     if BleedLevel <= 2 then
@@ -190,7 +177,6 @@ function ResetAllInjuries()
     for _, v in pairs(BodyParts) do
         v.isDamaged = false
         v.severity = 0
-        v.injuries = {}
     end
     
     NumInjuries = 0
@@ -230,9 +216,7 @@ function CreateInjury(bodyPart, bone, maxSeverity)
 
     local severity = math.random(1, maxSeverity)
     DamageBodyPart(bone, severity)
-    bodyPart.injuries[bodyPart.injuries + 1] = {
-        severity = severity,
-    }
+    bodyPart.severity = severity
     NumInjuries += 1
 end
 

--- a/client/wounding.lua
+++ b/client/wounding.lua
@@ -3,11 +3,8 @@ local prevPos = vec3(0.0, 0.0, 0.0)
 local function getWorstInjury()
     local level = 0
     for _, bodyPart in pairs(BodyParts) do
-        for i = 1, #bodyPart.injuries do
-            local injury = bodyPart.injuries[i]
-            if injury.severity > level then
-                level = injury.severity
-            end
+        if bodyPart.severity > level then
+            level = bodyPart.severity
         end
     end
 


### PR DESCRIPTION
I made the following observations

- Only one injury is allowed per body part
- An injury only holds a severity
- a bodypart has a severity that is kept in sync with the bodypart's injuries' severity

This leads to the conclusion that injuries can be removed in favor of using the bodypart's severity directly to make the code simpler.