### PR TITLE
refactor: weapons that damage player synced more efficiently with server

### DIFF
--- a/client/damage/damage.lua
+++ b/client/damage/damage.lua
@@ -21,37 +21,22 @@ local function injureBodyPart(bone)
     end
 end
 
----@param array any[]
----@param value any
----@return boolean found
-local function isInArray(array, value)
-    if not array then return false end
-
-    for i = 1, #array do
-        if array[i] == value then
-            return true
-        end
-    end
-
-    return false
-end
-
 ---Adds weapon hashes that damaged the ped that aren't already in the CurrentDamagedList and syncs to the server.
 local function findDamageCause()
     local detected = false
     for hash, weapon in pairs(exports.qbx_core:GetWeapons()) do
-        if HasPedBeenDamagedByWeapon(cache.ped, hash, 0) and not isInArray(CurrentDamageList, hash) then
+        if HasPedBeenDamagedByWeapon(cache.ped, hash, 0) and not WeaponsThatDamagedPlayer[hash] then
             detected = true
             TriggerEvent('chat:addMessage', {
                 color = { 255, 0, 0 },
                 multiline = false,
                 args = { Lang:t('info.status'), weapon.damagereason }
             })
-            CurrentDamageList[#CurrentDamageList + 1] = hash
+            WeaponsThatDamagedPlayer[hash] = true
         end
     end
     if detected then
-        lib.callback('qbx_medical:server:SetWeaponWounds', false, false, CurrentDamageList)
+        lib.callback('qbx_medical:server:SetWeaponWounds', false, false, WeaponsThatDamagedPlayer)
     end
 end
 

--- a/client/damage/damage.lua
+++ b/client/damage/damage.lua
@@ -23,20 +23,17 @@ end
 
 ---Adds weapon hashes that damaged the ped that aren't already in the CurrentDamagedList and syncs to the server.
 local function findDamageCause()
-    local detected = false
-    for hash, weapon in pairs(exports.qbx_core:GetWeapons()) do
+    for hash in pairs(exports.qbx_core:GetWeapons()) do
         if HasPedBeenDamagedByWeapon(cache.ped, hash, 0) and not WeaponsThatDamagedPlayer[hash] then
-            detected = true
             TriggerEvent('chat:addMessage', {
                 color = { 255, 0, 0 },
                 multiline = false,
                 args = { Lang:t('info.status'), weapon.damagereason }
             })
             WeaponsThatDamagedPlayer[hash] = true
+            ---TODO: verify that this only executes once for the loop and can therefore return early.
+            TriggerServerEvent('qbx_medical:server:playerDamagedByWeapon', hash)
         end
-    end
-    if detected then
-        lib.callback('qbx_medical:server:SetWeaponWounds', false, false, WeaponsThatDamagedPlayer)
     end
 end
 

--- a/client/damage/damage.lua
+++ b/client/damage/damage.lua
@@ -23,7 +23,7 @@ end
 
 ---Adds weapon hashes that damaged the ped that aren't already in the CurrentDamagedList and syncs to the server.
 local function findDamageCause()
-    for hash in pairs(exports.qbx_core:GetWeapons()) do
+    for hash, weapon in pairs(exports.qbx_core:GetWeapons()) do
         if HasPedBeenDamagedByWeapon(cache.ped, hash, 0) and not WeaponsThatDamagedPlayer[hash] then
             TriggerEvent('chat:addMessage', {
                 color = { 255, 0, 0 },

--- a/client/main.lua
+++ b/client/main.lua
@@ -143,7 +143,7 @@ end
 --- TODO: this export should not check any conditions, but force the ped to limp instead.
 exports('makePedLimp', MakePedLimp)
 
-function ResetMinorInjuries()
+local function resetMinorInjuries()
     for _, bodyPart in pairs(BodyParts) do
         if bodyPart.severity > 0 and bodyPart.severity <= 2 then
             bodyPart.severity = 0
@@ -168,9 +168,7 @@ function ResetMinorInjuries()
     doLimbAlert()
 end
 
-exports('resetMinorInjuries', ResetMinorInjuries)
-
-function ResetAllInjuries()
+local function resetAllInjuries()
     for _, v in pairs(BodyParts) do
         v.severity = 0
     end
@@ -188,15 +186,12 @@ function ResetAllInjuries()
     })
 
     WeaponsThatDamagedPlayer = {}
-    lib.callback('qbx_medical:server:SetWeaponWounds', false, false, WeaponsThatDamagedPlayer)
 
     SendBleedAlert()
     MakePedLimp()
     doLimbAlert()
     lib.callback('qbx_medical:server:resetHungerAndThirst')
 end
-
-exports('resetAllInjuries', ResetAllInjuries)
 
 function DamageBodyPart(bone, severity)
     BodyParts[bone].severity = severity
@@ -244,9 +239,9 @@ end)
 ---@param type? "full"|any heals all wounds if full otherwise heals only major wounds.
 lib.callback.register('qbx_medical:client:heal', function(type)
     if type == "full" then
-        ResetAllInjuries()
+        resetAllInjuries()
     else
-        ResetMinorInjuries()
+        resetMinorInjuries()
     end
     exports.qbx_core:Notify(Lang:t('success.wounds_healed'), 'success')
 end)
@@ -272,8 +267,8 @@ end
 exports('getPatientStatus', getPatientStatus)
 
 ---Revives player, healing all injuries
----Intended to be called from client or server.
 RegisterNetEvent('qbx_medical:client:playerRevived', function()
+    if source then return end
     local ped = cache.ped
 
     if IsDead or InLaststand then
@@ -288,7 +283,7 @@ RegisterNetEvent('qbx_medical:client:playerRevived', function()
     SetEntityHealth(ped, 200)
     ClearPedBloodDamage(ped)
     SetPlayerSprint(cache.playerId, true)
-    ResetAllInjuries()
+    resetAllInjuries()
     ResetPedMovementClipset(ped, 0.0)
     TriggerServerEvent('hud:server:RelieveStress', 100)
     exports.qbx_core:Notify(Lang:t('info.healthy'), 'inform')

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,5 +1,5 @@
----@type number[] weapon hashes
-CurrentDamageList = {}
+---@type table<number, boolean> weapon hashes as a set
+WeaponsThatDamagedPlayer = {}
 
 NumInjuries = 0
 
@@ -187,8 +187,8 @@ function ResetAllInjuries()
         isBleeding = BleedLevel
     })
 
-    CurrentDamageList = {}
-    lib.callback('qbx_medical:server:SetWeaponWounds', false, false, CurrentDamageList)
+    WeaponsThatDamagedPlayer = {}
+    lib.callback('qbx_medical:server:SetWeaponWounds', false, false, WeaponsThatDamagedPlayer)
 
     SendBleedAlert()
     MakePedLimp()

--- a/server/main.lua
+++ b/server/main.lua
@@ -2,21 +2,19 @@
 ---@field limbs BodyParts
 ---@field isBleeding number
 
----@type table<source, PlayerStatus>
+---@alias Source number
+
+---@type table<Source, PlayerStatus>
 local playerStatus = {}
 
----@type table<source, number[]> weapon hashes
-local playerWeaponWounds = {}
+---@type table<Source, table<number, boolean>> weapon hashes
+local WeaponsThatDamagedPlayers = {}
 
 local triggerEventHooks = require 'modules.hooks.server'
 
----@param data number[] weapon hashes
-lib.callback.register('qbx_medical:server:setWeaponWounds', function(source, data)
-	playerWeaponWounds[source] = data
-end)
-
-lib.callback.register('qbx_medical:server:clearWeaponWounds', function(source)
-	playerWeaponWounds[source] = nil
+RegisterNetEvent('qbx_medical:server:playerDamagedByWeapon', function(hash)
+	if WeaponsThatDamagedPlayers[source][hash] then return end
+	WeaponsThatDamagedPlayers[source][hash] = true
 end)
 
 ---@param player table|number
@@ -26,7 +24,7 @@ local function revivePlayer(player)
 	end
 	player.Functions.SetMetaData("isdead", false)
 	player.Functions.SetMetaData("inlaststand", false)
-	playerWeaponWounds[player.PlayerData.source] = nil
+	WeaponsThatDamagedPlayers[player.PlayerData.source] = nil
 	TriggerClientEvent('qbx_medical:client:playerRevived', player.PlayerData.source)
 end
 
@@ -86,7 +84,7 @@ lib.callback.register('hospital:GetPlayerStatus', function(_, playerId)
 		damage.damagedBodyParts = getDamagedBodyParts(playerInjuries.limbs)
 	end
 
-	damage.weaponWounds = playerWeaponWounds[playerSource] or {}
+	damage.weaponWounds = WeaponsThatDamagedPlayers[playerSource] or {}
 	return damage
 end)
 


### PR DESCRIPTION
- changed to a set (table<hash, boolean>) for more efficient lookups
- renamed variable to be more descriptive
- removing client side exports for reviving as this should originate from the server
- syncing less data to the server (only when a new weapon damages a player it sends that one only instead of all previous weapons)
- removed unneeded callbacks. i.e. the server asks the client to revive themselves, and clears the set rather than have the client callback to the server to do it