### PR TITLE
refactor: move static body part fields to config

### DIFF
--- a/client/damage/damage-effects.lua
+++ b/client/damage/damage-effects.lua
@@ -4,10 +4,10 @@ local headCount = 0
 
 ---based off of injuries to leg bodyparts of a certain severity.
 ---@param bodyPartKey BodyPartKey
----@param bodyPart BodyPart
+---@param severity number
 ---@return boolean isLegDamaged if leg is considered damaged
-local function isLegDamaged(bodyPartKey, bodyPart)
-    return (bodyPartKey == 'LLEG' and bodyPart.severity > 1) or (bodyPartKey == 'RLEG' and bodyPart.severity > 1) or (bodyPartKey == 'LFOOT' and bodyPart.severity > 2) or (bodyPartKey == 'RFOOT' and bodyPart.severity > 2)
+local function isLegDamaged(bodyPartKey, severity)
+    return (bodyPartKey == 'LLEG' and severity > 1) or (bodyPartKey == 'RLEG' and severity > 1) or (bodyPartKey == 'LFOOT' and severity > 2) or (bodyPartKey == 'RFOOT' and severity > 2)
 end
 
 ---shake camera and ragdoll player forward
@@ -29,18 +29,18 @@ end
 
 ---checks if left arm is damaged based off of injury location and severity.
 ---@param bodyPartKey BodyPartKey
----@param bodyPart BodyPart
+---@param severity integer
 ---@return boolean isDamaged true if the left arm is damaged
-local function isLeftArmDamaged(bodyPartKey, bodyPart)
-    return (bodyPartKey == 'LARM' and bodyPart.severity > 1) or (bodyPartKey == 'LHAND' and bodyPart.severity > 1) or (bodyPartKey == 'LFINGER' and bodyPart.severity > 2)
+local function isLeftArmDamaged(bodyPartKey, severity)
+    return (bodyPartKey == 'LARM' and severity > 1) or (bodyPartKey == 'LHAND' and severity > 1) or (bodyPartKey == 'LFINGER' and severity > 2)
 end
 
 ---checks if either arm is damaged based on injury location and severity.
 ---@param bodyPartKey BodyPartKey
----@param bodyPart BodyPart
+---@param severity integer
 ---@return boolean isDamaged true if either arm is damaged
-local function isArmDamaged(bodyPartKey, bodyPart)
-    return isLeftArmDamaged(bodyPartKey, bodyPart) or (bodyPartKey == 'RARM' and bodyPart.severity > 1) or (bodyPartKey == 'RHAND' and bodyPart.severity > 1) or (bodyPartKey == 'RFINGER' and bodyPart.severity > 2)
+local function isArmDamaged(bodyPartKey, severity)
+    return isLeftArmDamaged(bodyPartKey, severity) or (bodyPartKey == 'RARM' and severity > 1) or (bodyPartKey == 'RHAND' and severity > 1) or (bodyPartKey == 'RFINGER' and severity > 2)
 end
 
 ---enforce following arm disabilities on the player for a set time period:
@@ -70,10 +70,10 @@ end
 
 ---returns whether the player's head is damaged based on injury location and severity.
 ---@param bodyPartKey BodyPartKey
----@param bodyPart BodyPart
+---@param severity integer
 ---@return boolean
-local function isHeadDamaged(bodyPartKey, bodyPart)
-    return bodyPartKey == 'HEAD' and bodyPart.severity > 2
+local function isHeadDamaged(bodyPartKey, severity)
+    return bodyPartKey == 'HEAD' and severity > 2
 end
 
 ---flash screen, fade out, ragdoll, fade in.
@@ -99,24 +99,24 @@ end
 function ApplyDamageEffects()
     local ped = cache.ped
     if IsDead or InLaststand then return end
-    for bodyPartKey, bodyPart in pairs(BodyParts) do
-        if isLegDamaged(bodyPartKey, bodyPart) then
+    for bodyPartKey, severity in pairs(Injuries) do
+        if isLegDamaged(bodyPartKey, severity) then
             if legCount >= Config.LegInjuryTimer then
                 chancePedFalls(ped)
                 legCount = 0
             else
                 legCount += 1
             end
-        elseif isArmDamaged(bodyPartKey, bodyPart) then
+        elseif isArmDamaged(bodyPartKey, severity) then
             if armCount >= Config.ArmInjuryTimer then
                 CreateThread(function()
-                    disableArms(ped, isLeftArmDamaged(bodyPartKey, bodyPart))
+                    disableArms(ped, isLeftArmDamaged(bodyPartKey, severity))
                 end)
                 armCount = 0
             else
                 armCount += 1
             end
-        elseif isHeadDamaged(bodyPartKey, bodyPart) then
+        elseif isHeadDamaged(bodyPartKey, severity) then
             if headCount >= Config.HeadInjuryTimer then
                 local chance = math.random(100)
 

--- a/client/wounding.lua
+++ b/client/wounding.lua
@@ -2,9 +2,9 @@ local prevPos = vec3(0.0, 0.0, 0.0)
 
 local function getWorstInjury()
     local level = 0
-    for _, bodyPart in pairs(BodyParts) do
-        if bodyPart.severity > level then
-            level = bodyPart.severity
+    for _, severity in pairs(Injuries) do
+        if severity > level then
+            level = severity
         end
     end
 

--- a/config.lua
+++ b/config.lua
@@ -114,10 +114,29 @@ Config.AlwaysBleedChanceWeapons = { -- Define which weapons will always cause bl
 }
 Config.AlwaysBleedChance = 70 -- Set the chance out of 100 that if a player is hit with a weapon, that also has a random chance, it will cause bleeding
 
-Config.BodyPart = {
-    NONE = 0,
-    HEAD = 1,
-    
+---@alias BodyPartKey string
+
+---@class BodyPart
+---@field label string
+---@field causeLimp boolean
+
+---@type table<BodyPartKey, BodyPart>
+Config.BodyParts = {
+    HEAD = { label = Lang:t('body.head'), causeLimp = false },
+    NECK = { label = Lang:t('body.neck'), causeLimp = false },
+    SPINE = { label = Lang:t('body.spine'), causeLimp = true },
+    UPPER_BODY = { label = Lang:t('body.upper_body'), causeLimp = false },
+    LOWER_BODY = { label = Lang:t('body.lower_body'), causeLimp = true },
+    LARM = { label = Lang:t('body.left_arm'), causeLimp = false, },
+    LHAND = { label = Lang:t('body.left_hand'), causeLimp = false, },
+    LFINGER = { label = Lang:t('body.left_fingers'), causeLimp = false, },
+    LLEG = { label = Lang:t('body.left_leg'), causeLimp = true, },
+    LFOOT = { label = Lang:t('body.left_foot'), causeLimp = true, },
+    RARM = { label = Lang:t('body.right_arm'), causeLimp = false, },
+    RHAND = { label = Lang:t('body.right_hand'), causeLimp = false, },
+    RFINGER = { label = Lang:t('body.right_fingers'), causeLimp = false, },
+    RLEG = { label = Lang:t('body.right_leg'), causeLimp = true, },
+    RFOOT = { label = Lang:t('body.right_foot'), causeLimp = true, },
 }
 
 ---@type table<number, string>

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,5 +1,5 @@
 ---@class PlayerStatus
----@field limbs BodyParts
+---@field injuries table<BodyPartKey, integer>
 ---@field isBleeding number
 
 ---@alias Source number
@@ -47,18 +47,6 @@ lib.callback.register('qbx_medical:server:syncInjuries', function(source, data)
 	playerStatus[source] = data
 end)
 
----@param limbs BodyParts
----@return BodyParts
-local function getDamagedBodyParts(limbs)
-	local bodyParts = {}
-	for bone, bodyPart in pairs(limbs) do
-		if bodyPart.severity > 0 then
-			bodyParts[bone] = bodyPart
-		end
-	end
-	return bodyParts
-end
-
 ---@param playerId number
 lib.callback.register('hospital:GetPlayerStatus', function(_, playerId)
 	local playerSource = exports.qbx_core:GetPlayer(playerId).PlayerData.source
@@ -81,7 +69,7 @@ lib.callback.register('hospital:GetPlayerStatus', function(_, playerId)
 	local playerInjuries = playerStatus[playerSource]
 	if playerInjuries then
 		damage.bleedLevel = playerInjuries.isBleeding or 0
-		damage.damagedBodyParts = getDamagedBodyParts(playerInjuries.limbs)
+		damage.damagedBodyParts = playerInjuries.injuries
 	end
 
 	damage.weaponWounds = WeaponsThatDamagedPlayers[playerSource] or {}


### PR DESCRIPTION
- move body parts to config (static fields)
- split off injuries from body parts and represent as map of body part key to severity to represent the structure that a bodypart has a severity that is changed. A bodypart not being in the Injuries table means that it isn't injured