### PR TITLE
refactor: proper ox implementation and style fixes

### DIFF
--- a/client/damage/apply-damage-effects.lua
+++ b/client/damage/apply-damage-effects.lua
@@ -56,10 +56,9 @@ local function disableArms(ped, leftArmDamaged)
             DisableControlAction(0, 63, true) -- veh turn left
         end
 
-        local playerId = cache.playerId
-        if IsPlayerFreeAiming(playerId) then
+        if IsPlayerFreeAiming(cache.playerId) then
             if leftArmDamaged then
-                DisablePlayerFiring(playerId, true) -- Disable weapon firing
+                DisablePlayerFiring(cache.playerId, true) -- Disable weapon firing
             else
                 DisableControlAction(0, 25, true) -- Disable weapon aiming
             end
@@ -99,12 +98,11 @@ end
 
 ---applies disabling status effects based on injuries to specific body parts
 function ApplyDamageEffects()
-    local ped = cache.ped
     if DeathState ~= sharedConfig.deathState.ALIVE then return end
     for bodyPartKey, injury in pairs(Injuries) do
         if isLegDamaged(bodyPartKey, injury.severity) then
             if legCount >= config.legInjuryTimer then
-                chancePedFalls(ped)
+                chancePedFalls(cache.ped)
                 legCount = 0
             else
                 legCount += 1
@@ -112,7 +110,7 @@ function ApplyDamageEffects()
         elseif isArmDamaged(bodyPartKey, injury.severity) then
             if armCount >= config.armInjuryTimer then
                 CreateThread(function()
-                    disableArms(ped, isLeftArmDamaged(bodyPartKey, injury.severity))
+                    disableArms(cache.ped, isLeftArmDamaged(bodyPartKey, injury.severity))
                 end)
                 armCount = 0
             else
@@ -123,7 +121,7 @@ function ApplyDamageEffects()
                 local chance = math.random(100)
 
                 if chance <= config.headInjuryChance then
-                    playBrainDamageEffectAndRagdoll(ped)
+                    playBrainDamageEffectAndRagdoll(cache.ped)
                 end
                 headCount = 0
             else

--- a/client/damage/damage.lua
+++ b/client/damage/damage.lua
@@ -193,9 +193,8 @@ end
 
 ---detects if player took damage, applies injuries, and updates health/armor values
 local function checkForDamage()
-    local ped = cache.ped
-    local health = GetEntityHealth(ped)
-    local armor = GetPedArmour(ped)
+    local health = GetEntityHealth(cache.ped)
+    local armor = GetPedArmour(cache.ped)
 
     initHealthAndArmorIfNotSet(health, armor)
 
@@ -204,7 +203,7 @@ local function checkForDamage()
 
     if isArmorDamaged or isHealthDamaged then
         local damageDone = (Hp - health)
-        local weaponHash = applyDamage(ped, damageDone, isArmorDamaged)
+        local weaponHash = applyDamage(cache.ped, damageDone, isArmorDamaged)
         if weaponHash and not WeaponsThatDamagedPlayer[weaponHash] then
             TriggerEvent('chat:addMessage', {
                 color = { 255, 0, 0 },
@@ -213,7 +212,7 @@ local function checkForDamage()
             })
             WeaponsThatDamagedPlayer[weaponHash] = true
         end
-        ClearEntityLastDamageEntity(ped)
+        ClearEntityLastDamageEntity(cache.ped)
     end
 
     Hp = health

--- a/client/dead.lua
+++ b/client/dead.lua
@@ -1,21 +1,21 @@
 local sharedConfig = require 'config.shared'
+local WEAPONS = exports.qbx_core:GetWeapons()
 local allowRespawn = false
 
 local function playDeadAnimation()
-    local ped = cache.ped
-    local deadAnimDict = "dead"
-    local deadAnim = "dead_a"
-    local deadVehAnimDict = "veh@low@front_ps@idle_duck"
-    local deadVehAnim = "sit"
+    local deadAnimDict = 'dead'
+    local deadAnim = 'dead_a'
+    local deadVehAnimDict = 'veh@low@front_ps@idle_duck'
+    local deadVehAnim = 'sit'
 
     if cache.vehicle then
-        if not IsEntityPlayingAnim(ped, deadVehAnimDict, deadVehAnim, 3) then
-            lib.requestAnimDict(deadVehAnimDict)
-            TaskPlayAnim(ped, deadVehAnimDict, deadVehAnim, 1.0, 1.0, -1, 1, 0, false, false, false)
+        if not IsEntityPlayingAnim(cache.ped, deadVehAnimDict, deadVehAnim, 3) then
+            lib.requestAnimDict(deadVehAnimDict, 5000)
+            TaskPlayAnim(cache.ped, deadVehAnimDict, deadVehAnim, 1.0, 1.0, -1, 1, 0, false, false, false)
         end
-    elseif not IsEntityPlayingAnim(ped, deadAnimDict, deadAnim, 3) then
-        lib.requestAnimDict(deadAnimDict)
-        TaskPlayAnim(ped, deadAnimDict, deadAnim, 1.0, 1.0, -1, 1, 0, false, false, false)
+    elseif not IsEntityPlayingAnim(cache.ped, deadAnimDict, deadAnim, 3) then
+        lib.requestAnimDict(deadAnimDict, 5000)
+        TaskPlayAnim(cache.ped, deadAnimDict, deadAnim, 1.0, 1.0, -1, 1, 0, false, false, false)
     end
 end
 
@@ -27,11 +27,11 @@ function OnDeath()
     SetDeathState(sharedConfig.deathState.DEAD)
     TriggerEvent('qbx_medical:client:onPlayerDied')
     TriggerServerEvent('qbx_medical:server:onPlayerDied')
-    TriggerServerEvent("InteractSound_SV:PlayOnSource", "demo", 0.1)
+    TriggerServerEvent('InteractSound_SV:PlayOnSource', 'demo', 0.1)
     local player = cache.ped
 
     WaitForPlayerToStopMoving()
-    
+
     CreateThread(function()
         while DeathState == sharedConfig.deathState.DEAD do
             DisableControls()
@@ -39,7 +39,7 @@ function OnDeath()
             Wait(0)
         end
     end)
-    
+
     ResurrectPlayer()
     playDeadAnimation()
     SetEntityInvincible(player, true)
@@ -52,9 +52,9 @@ local function respawn()
     local success = lib.callback.await('qbx_medical:server:respawn')
     if not success then return end
     if exports.qbx_policejob:IsHandcuffed() then
-        TriggerEvent("police:client:GetCuffed", -1)
+        TriggerEvent('police:client:GetCuffed', -1)
     end
-    TriggerEvent("police:client:DeEscort")
+    TriggerEvent('police:client:DeEscort')
 end
 
 ---Allow player to respawn
@@ -92,20 +92,20 @@ end)
 ---@param attacker number ped
 ---@param weapon string weapon hash
 local function logDeath(victim, attacker, weapon)
-    local playerid = NetworkGetPlayerIndexFromPed(victim)
-    local playerName = GetPlayerName(playerid) .. " " .. "(" .. GetPlayerServerId(playerid) .. ")" or Lang:t('info.self_death')
+    local playerId = NetworkGetPlayerIndexFromPed(victim)
+    local playerName = GetPlayerName(playerId) .. ' ' .. '(' .. GetPlayerServerId(playerId) .. ')' or Lang:t('info.self_death')
     local killerId = NetworkGetPlayerIndexFromPed(attacker)
-    local killerName = GetPlayerName(killerId) .. " " .. "(" .. GetPlayerServerId(killerId) .. ")" or Lang:t('info.self_death')
-    local weaponLabel = exports.qbx_core:GetWeapons()[weapon].label or 'Unknown'
-    local weaponName = exports.qbx_core:GetWeapons()[weapon].name or 'Unknown'
-    TriggerServerEvent("qb-log:server:CreateLog", "death", Lang:t('logs.death_log_title', { playername = playerName, playerid = GetPlayerServerId(playerid) }), "red", Lang:t('logs.death_log_message', { killername = killerName, playername = playerName, weaponlabel = weaponLabel, weaponname = weaponName }))
+    local killerName = GetPlayerName(killerId) .. ' ' .. '(' .. GetPlayerServerId(killerId) .. ')' or Lang:t('info.self_death')
+    local weaponLabel = WEAPONS[weapon].label or 'Unknown'
+    local weaponName = WEAPONS[weapon].name or 'Unknown'
+    TriggerServerEvent('qb-log:server:CreateLog', 'death', Lang:t('logs.death_log_title', { playername = playerName, playerid = GetPlayerServerId(playerId) }), 'red', Lang:t('logs.death_log_message', { killername = killerName, playername = playerName, weaponlabel = weaponLabel, weaponname = weaponName }))
 end
 
 ---when player is killed by another player, set last stand mode, or if already in last stand mode, set player to dead mode.
 ---@param event string
 ---@param data table
 AddEventHandler('gameEventTriggered', function(event, data)
-    if event ~= "CEventNetworkEntityDamage" then return end
+    if event ~= 'CEventNetworkEntityDamage' then return end
     local victim, attacker, victimDied, weapon = data[1], data[2], data[4], data[7]
     if not IsEntityAPed(victim) or not victimDied or NetworkGetPlayerIndexFromPed(victim) ~= cache.playerId or not IsEntityDead(cache.ped) then return end
     if DeathState == sharedConfig.deathState.ALIVE then

--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -1,57 +1,49 @@
 local config = require 'config.client'
 local sharedConfig = require 'config.shared'
+local WEAPONS = exports.qbx_core:GetWeapons()
 
 ---blocks until ped is no longer moving
----@param ped number
 function WaitForPlayerToStopMoving()
-    local ped = cache.ped
-    local TimeOut = 10000
-    while GetEntitySpeed(ped) > 0.5 or IsPedRagdoll(ped) and TimeOut > 1 do TimeOut -= 10 Wait(10) end
+    local timeOut = 10000
+    while GetEntitySpeed(cache.ped) > 0.5 or IsPedRagdoll(cache.ped) and timeOut > 1 do timeOut -= 10 Wait(10) end
 end
 
 --- low level GTA resurrection
 function ResurrectPlayer()
-    local ped = cache.ped
-    local pos = GetEntityCoords(ped)
-    local heading = GetEntityHeading(ped)
-    local veh = cache.vehicle
-    local seat = cache.seat
+    local pos = GetEntityCoords(cache.ped)
+    local heading = GetEntityHeading(cache.ped)
 
     NetworkResurrectLocalPlayer(pos.x, pos.y, pos.z + 0.5, heading, true, false)
-    if veh then
-        SetPedIntoVehicle(ped, veh, seat)
+    if cache.vehicle then
+        SetPedIntoVehicle(cache.ped, cache.vehicle, cache.seat)
     end
 end
 
 ---remove last stand mode from player.
 function EndLastStand()
-    local ped = cache.ped
-    TaskPlayAnim(ped, LastStandDict, "exit", 1.0, 8.0, -1, 1, -1, false, false, false)
+    TaskPlayAnim(cache.ped, LastStandDict, 'exit', 1.0, 8.0, -1, 1, -1, false, false, false)
     LaststandTime = 0
     TriggerServerEvent('qbx_medical:server:onPlayerLaststandEnd')
 end
 
 local function logPlayerKiller()
-    local ped = cache.ped
-    local player = cache.playerId
-    local killer_2, killerWeapon = NetworkGetEntityKillerOfPlayer(player)
-    local killer = GetPedSourceOfDeath(ped)
+    local killer_2, killerWeapon = NetworkGetEntityKillerOfPlayer(cache.playerId)
+    local killer = GetPedSourceOfDeath(cache.ped)
     if killer_2 ~= 0 and killer_2 ~= -1 then killer = killer_2 end
     local killerId = NetworkGetPlayerIndexFromPed(killer)
-    local killerName = killerId ~= -1 and GetPlayerName(killerId) .. " " .. "(" .. GetPlayerServerId(killerId) .. ")" or Lang:t('info.self_death')
+    local killerName = killerId ~= -1 and GetPlayerName(killerId) .. ' ' .. '(' .. GetPlayerServerId(killerId) .. ')' or Lang:t('info.self_death')
     local weaponLabel = Lang:t('info.wep_unknown')
     local weaponName = Lang:t('info.wep_unknown')
-    local weaponItem = exports.qbx_core:GetWeapons()[killerWeapon]
+    local weaponItem = WEAPONS[killerWeapon]
     if weaponItem then
         weaponLabel = weaponItem.label
         weaponName = weaponItem.name
     end
-    TriggerServerEvent("qb-log:server:CreateLog", "death", Lang:t('logs.death_log_title', { playername = GetPlayerName(cache.playerId), playerid = GetPlayerServerId(player) }), "red", Lang:t('logs.death_log_message', { killername = killerName, playername = GetPlayerName(player), weaponlabel = weaponLabel, weaponname = weaponName }))
+    TriggerServerEvent('qb-log:server:CreateLog', 'death', Lang:t('logs.death_log_title', { playername = GetPlayerName(cache.playerId), playerid = GetPlayerServerId(cache.playerId) }), 'red', Lang:t('logs.death_log_message', { killername = killerName, playername = GetPlayerName(cache.playerId), weaponlabel = weaponLabel, weaponname = weaponName }))
 end
 
 ---count down last stand, if last stand is over, put player in death mode and log the killer.
 local function countdownLastStand()
-    
     if LaststandTime - 1 > 0 then
         LaststandTime -= 1
     else
@@ -66,13 +58,12 @@ end
 
 ---put player in last stand mode and notify EMS.
 function StartLastStand()
-    local ped = cache.ped
     Wait(1000)
     WaitForPlayerToStopMoving()
-    TriggerServerEvent("InteractSound_SV:PlayOnSource", "demo", 0.1)
+    TriggerServerEvent('InteractSound_SV:PlayOnSource', 'demo', 0.1)
     LaststandTime = config.laststandReviveInterval
     ResurrectPlayer()
-    SetEntityHealth(ped, 150)
+    SetEntityHealth(cache.ped, 150)
     PlayUnescortedLastStandAnimation()
     SetDeathState(sharedConfig.deathState.LAST_STAND)
     TriggerEvent('qbx_medical:client:onPlayerLaststand')

--- a/client/load-unload.lua
+++ b/client/load-unload.lua
@@ -29,9 +29,7 @@ local function onPlayerLoaded()
     pcall(function() exports.spawnmanager:setAutoSpawn(false) end)
     CreateThread(function()
         Wait(1000)
-        local ped = cache.ped
-        local playerId = cache.playerId
-        initHealthAndArmor(ped, playerId, QBX.PlayerData.metadata)
+        initHealthAndArmor(cache.ped, cache.playerId, QBX.PlayerData.metadata)
         initDeathAndLastStand(QBX.PlayerData.metadata)
     end)
 end
@@ -39,6 +37,6 @@ end
 AddEventHandler('QBCore:Client:OnPlayerLoaded', onPlayerLoaded)
 
 AddEventHandler('onResourceStart', function(resourceName)
-    if GetCurrentResourceName() ~= resourceName then return end
+    if cache.resource ~= resourceName then return end
     onPlayerLoaded()
 end)

--- a/client/main.lua
+++ b/client/main.lua
@@ -52,8 +52,8 @@ Hp = nil
 DeathTime = 0
 LaststandTime = 0
 RespawnHoldTime = 5
-LastStandDict = "combat@damage@writhe"
-LastStandAnim = "writhe_loop"
+LastStandDict = 'combat@damage@writhe'
+LastStandAnim = 'writhe_loop'
 
 exports('isDead', function()
     return DeathState == sharedConfig.deathState.DEAD
@@ -101,7 +101,7 @@ local function doLimbAlert()
             limbDamageMsg = limbDamageMsg .. Lang:t('info.pain_message', { limb = bodyPart.label, severity = sharedConfig.woundLevels[injury.severity].label})
             i += 1
             if i < NumInjuries then
-                limbDamageMsg = limbDamageMsg .. " | "
+                limbDamageMsg = limbDamageMsg .. ' | '
             end
         end
     else
@@ -113,8 +113,8 @@ end
 ---sets ped animation to limping and prevents running.
 function MakePedLimp()
     if not isInjuryCausingLimp() then return end
-    lib.requestAnimSet("move_m@injured")
-    SetPedMovementClipset(cache.ped, "move_m@injured", 1)
+    lib.requestAnimSet('move_m@injured', 5000)
+    SetPedMovementClipset(cache.ped, 'move_m@injured', 1)
     SetPlayerSprint(cache.playerId, false)
 end
 
@@ -183,9 +183,9 @@ function ApplyBleed(level)
 end
 
 ---heals player wounds.
----@param type? "full"|any heals all wounds if full otherwise heals only major wounds.
+---@param type? 'full'|any heals all wounds if full otherwise heals only major wounds.
 lib.callback.register('qbx_medical:client:heal', function(type)
-    if type == "full" then
+    if type == 'full' then
         resetAllInjuries()
     else
         resetMinorInjuries()
@@ -202,22 +202,20 @@ end)
 
 ---Revives player, healing all injuries
 RegisterNetEvent('qbx_medical:client:playerRevived', function()
-    local ped = cache.ped
-
     if DeathState ~= sharedConfig.deathState.ALIVE then
-        local pos = GetEntityCoords(ped, true)
-        NetworkResurrectLocalPlayer(pos.x, pos.y, pos.z, GetEntityHeading(ped), true, false)
+        local pos = GetEntityCoords(cache.ped, true)
+        NetworkResurrectLocalPlayer(pos.x, pos.y, pos.z, GetEntityHeading(cache.ped), true, false)
         SetDeathState(sharedConfig.deathState.ALIVE)
-        SetEntityInvincible(ped, false)
+        SetEntityInvincible(cache.ped, false)
         EndLastStand()
     end
 
-    SetEntityMaxHealth(ped, 200)
-    SetEntityHealth(ped, 200)
-    ClearPedBloodDamage(ped)
+    SetEntityMaxHealth(cache.ped, 200)
+    SetEntityHealth(cache.ped, 200)
+    ClearPedBloodDamage(cache.ped)
     SetPlayerSprint(cache.playerId, true)
     resetAllInjuries()
-    ResetPedMovementClipset(ped, 0.0)
+    ResetPedMovementClipset(cache.ped, 0.0)
     TriggerServerEvent('hud:server:RelieveStress', 100)
     exports.qbx_core:Notify(Lang:t('info.healthy'), 'inform')
 end)

--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -1,18 +1,17 @@
 local isEscorted = false
-local vehicleDict = "veh@low@front_ps@idle_duck"
-local vehicleAnim = "sit"
+local vehicleDict = 'veh@low@front_ps@idle_duck'
+local vehicleAnim = 'sit'
 
 function PlayUnescortedLastStandAnimation()
-    local ped = cache.ped
     if cache.vehicle then
-        lib.requestAnimDict(vehicleDict)
-        if not IsEntityPlayingAnim(ped, vehicleDict, vehicleAnim, 3) then
-            TaskPlayAnim(ped, vehicleDict, vehicleAnim, 1.0, 1.0, -1, 1, 0, false, false, false)
+        lib.requestAnimDict(vehicleDict, 5000)
+        if not IsEntityPlayingAnim(cache.ped, vehicleDict, vehicleAnim, 3) then
+            TaskPlayAnim(cache.ped, vehicleDict, vehicleAnim, 1.0, 1.0, -1, 1, 0, false, false, false)
         end
     else
-        lib.requestAnimDict(LastStandDict)
-        if not IsEntityPlayingAnim(ped, LastStandDict, LastStandAnim, 3) then
-            TaskPlayAnim(ped, LastStandDict, LastStandAnim, 1.0, 1.0, -1, 1, 0, false, false, false)
+        lib.requestAnimDict(LastStandDict, 5000)
+        if not IsEntityPlayingAnim(cache.ped, LastStandDict, LastStandAnim, 3) then
+            TaskPlayAnim(cache.ped, LastStandDict, LastStandAnim, 1.0, 1.0, -1, 1, 0, false, false, false)
         end
     end
 end
@@ -20,12 +19,12 @@ end
 ---@param ped number
 local function playEscortedLastStandAnimation(ped)
     if cache.vehicle then
-        lib.requestAnimDict(vehicleDict)
+        lib.requestAnimDict(vehicleDict, 5000)
         if IsEntityPlayingAnim(ped, vehicleDict, vehicleAnim, 3) then
             StopAnimTask(ped, vehicleDict, vehicleAnim, 3)
         end
     else
-        lib.requestAnimDict(LastStandDict)
+        lib.requestAnimDict(LastStandDict, 5000)
         if IsEntityPlayingAnim(ped, LastStandDict, LastStandAnim, 3) then
             StopAnimTask(ped, LastStandDict, LastStandAnim, 3)
         end

--- a/client/wounding.lua
+++ b/client/wounding.lua
@@ -27,7 +27,6 @@ CreateThread(function()
 end)
 
 local function makePlayerBlackout()
-    local ped = cache.ped
     SetFlash(0, 0, 100, 7000, 100)
 
     DoScreenFadeOut(500)
@@ -35,9 +34,9 @@ local function makePlayerBlackout()
         Wait(0)
     end
 
-    if not IsPedRagdoll(ped) and IsPedOnFoot(ped) and not IsPedSwimming(ped) then
+    if not IsPedRagdoll(cache.ped) and IsPedOnFoot(cache.ped) and not IsPedSwimming(cache.ped) then
         ShakeGameplayCam('SMALL_EXPLOSION_SHAKE', 0.08) -- change this float to increase/decrease camera shake
-        SetPedToRagdollWithFall(ped, 7500, 9000, 1, GetEntityForwardVector(ped), 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        SetPedToRagdollWithFall(cache.ped, 7500, 9000, 1, GetEntityForwardVector(cache.ped), 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     end
 
     Wait(1500)
@@ -57,16 +56,15 @@ end
 exports('makePlayerFadeOut', makePlayerFadeOut)
 
 local function applyBleedEffects()
-    local ped = cache.ped
     if not QBX.PlayerData then return end
     local bleedDamage = BleedLevel * config.bleedDamageTimer
-    ApplyDamageToPed(ped, bleedDamage, false)
+    ApplyDamageToPed(cache.ped, bleedDamage, false)
     SendBleedAlert()
     Hp -= bleedDamage
     local randX = math.random() + math.random(-1, 1)
     local randY = math.random() + math.random(-1, 1)
-    local coords = GetOffsetFromEntityInWorldCoords(ped, randX, randY, 0)
-    TriggerServerEvent("evidence:server:CreateBloodDrop", QBX.PlayerData.citizenid, QBX.PlayerData.metadata.bloodtype, coords)
+    local coords = GetOffsetFromEntityInWorldCoords(cache.ped, randX, randY, 0)
+    TriggerServerEvent('evidence:server:CreateBloodDrop', QBX.PlayerData.citizenid, QBX.PlayerData.metadata.bloodtype, coords)
 
     if AdvanceBleedTimer >= config.advanceBleedTimer then
         ApplyBleed(1)
@@ -128,12 +126,11 @@ end
 
 local function checkBleeding()
     if BleedLevel == 0 then return end
-    local player = cache.ped
     if BleedTickTimer >= config.bleedTickRate then
         handleBleeding()
         BleedTickTimer = 0
     else
-        bleedTick(player)
+        bleedTick(cache.ped)
     end
 end
 
@@ -163,6 +160,6 @@ end
 
 AddEventHandler('QBCore:Client:OnPlayerLoaded', savePlayerPos)
 AddEventHandler('onResourceStart', function(resourceName)
-    if GetCurrentResourceName() ~= resourceName then return end
+    if cache.resource ~= resourceName then return end
     savePlayerPos()
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -31,13 +31,13 @@ end)
 AddStateBagChangeHandler(DEATH_STATE_STATE_BAG, nil, function(bagName, _, value)
 	local playerId = GetPlayerFromStateBagName(bagName)
 	local player = exports.qbx_core:GetPlayer(playerId)
-	player.Functions.SetMetaData("isdead", value == sharedConfig.deathState.DEAD)
-	player.Functions.SetMetaData("inlaststand", value == sharedConfig.deathState.LAST_STAND)
+	player.Functions.SetMetaData('isdead', value == sharedConfig.deathState.DEAD)
+	player.Functions.SetMetaData('inlaststand', value == sharedConfig.deathState.LAST_STAND)
 end)
 
 ---@param player table|number
 local function revivePlayer(player)
-	if type(player) == "number" then
+	if type(player) == 'number' then
 		player = exports.qbx_core:GetPlayer(player)
 	end
 	TriggerClientEvent('qbx_medical:client:playerRevived', player.PlayerData.source)
@@ -46,7 +46,7 @@ end
 ---removes all ailments, sets to full health, and fills up hunger and thirst.
 ---@param src Source
 local function heal(src)
-	lib.callback('qbx_medical:client:heal', src, false, "full")
+	lib.callback('qbx_medical:client:heal', src, false, 'full')
 end
 
 exports('Heal', heal)
@@ -54,7 +54,7 @@ exports('Heal', heal)
 ---Removes any injuries with severity 2 or lower. Stops bleeding if bleed level is less than 3.
 ---@param src Source
 local function healPartially(src)
-	lib.callback('qbx_medical:client:heal', src, false, "partial")
+	lib.callback('qbx_medical:client:heal', src, false, 'partial')
 end
 
 exports('HealPartially', healPartially)
@@ -65,7 +65,7 @@ exports('HealPartially', healPartially)
 ---@field id number
 ---@param eventData EventData
 AddEventHandler('txAdmin:events:healedPlayer', function(eventData)
-	if GetInvokingResource() ~= "monitor" or type(eventData) ~= "table" or type(eventData.id) ~= "number" then
+	if GetInvokingResource() ~= 'monitor' or type(eventData) ~= 'table' or type(eventData.id) ~= 'number' then
 		return
 	end
 
@@ -95,7 +95,7 @@ local function getPlayerStatus(src)
 	for bodyPartKey, injury in pairs(injuries) do
         local bodyPart = sharedConfig.bodyParts[bodyPartKey]
 		i += 1
-        injuryStatuses[i] = bodyPart.label .. " (" .. sharedConfig.woundLevels[injury.severity].label .. ")"
+        injuryStatuses[i] = bodyPart.label .. ' (' .. sharedConfig.woundLevels[injury.severity].label .. ')'
 		weaponsThatDamagedPlayer[injury.weaponHash] = true
 	end
 
@@ -114,7 +114,7 @@ exports('GetPlayerStatus', getPlayerStatus)
 ---@param amount number
 lib.callback.register('qbx_medical:server:setArmor', function(source, amount)
 	local player = exports.qbx_core:GetPlayer(source)
-	player.Functions.SetMetaData("armor", amount)
+	player.Functions.SetMetaData('armor', amount)
 end)
 
 local function resetHungerAndThirst(player)
@@ -131,7 +131,7 @@ lib.callback.register('qbx_medical:server:resetHungerAndThirst', resetHungerAndT
 
 lib.addCommand('revive', {
     help = Lang:t('info.revive_player_a'),
-	restricted = "admin",
+	restricted = 'group.admin',
 	params = {
         { name = 'id', help = Lang:t('info.player_id'), type = 'playerId', optional = true },
     }
@@ -139,7 +139,7 @@ lib.addCommand('revive', {
 	if not args.id then args.id = source end
 	local player = exports.qbx_core:GetPlayer(tonumber(args.id))
 	if not player then
-		TriggerClientEvent('ox_lib:notify', source, { description = Lang:t('error.not_online'), type = 'error' })
+		exports.qbx_core:Notify(source, Lang:t('error.not_online'), 'error')
 		return
 	end
 	revivePlayer(args.id)
@@ -147,7 +147,7 @@ end)
 
 lib.addCommand('kill', {
     help =  Lang:t('info.kill'),
-	restricted = "admin",
+	restricted = 'group.admin',
 	params = {
         { name = 'id', help = Lang:t('info.player_id'), type = 'playerId', optional = true },
     }
@@ -155,7 +155,7 @@ lib.addCommand('kill', {
 	if not args.id then args.id = source end
 	local player = exports.qbx_core:GetPlayer(tonumber(args.id))
 	if not player then
-		TriggerClientEvent('ox_lib:notify', source, { description = Lang:t('error.not_online'), type = 'error' })
+		exports.qbx_core:Notify(source, Lang:t('error.not_online'), 'error')
 		return
 	end
 	lib.callback('qbx_medical:client:killPlayer', args.id)
@@ -163,7 +163,7 @@ end)
 
 lib.addCommand('aheal', {
     help =  Lang:t('info.heal_player_a'),
-	restricted = "admin",
+	restricted = 'group.admin',
 	params = {
         { name = 'id', help = Lang:t('info.player_id'), type = 'playerId', optional = true },
     }
@@ -171,7 +171,7 @@ lib.addCommand('aheal', {
 	if not args.id then args.id = source end
 	local player = exports.qbx_core:GetPlayer(tonumber(args.id))
 	if not player then
-		TriggerClientEvent('ox_lib:notify', source, { description = Lang:t('error.not_online'), type = 'error' })
+		exports.qbx_core:Notify(source, Lang:t('error.not_online'), 'error')
 		return
 	end
 	heal(args.id)


### PR DESCRIPTION
## Description

- Standardize `'` over `"`
- Proper usage and implementation of ox_lib's caching features
- Addition of 5000ms timeouts added to all ox_lib's streaming features
- Addition of constants for `exports.qbx_core:GetWeapons()`
- Replacment of the old ox_lib notifys to the new core notifies
- Other minor style fixes and changes

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
