### PR TITLE
fix: restoring health level when logging in

### DIFF
--- a/client/load-unload.lua
+++ b/client/load-unload.lua
@@ -5,8 +5,8 @@ local config = require 'config.client'
 ---@param playerId number
 ---@param playerMetadata any
 local function initHealthAndArmor(ped, playerId, playerMetadata)
-    SetEntityHealth(ped, playerMetadata.health)
     SetEntityMaxHealth(ped, 200)
+    SetEntityHealth(ped, playerMetadata.health)
     SetPlayerHealthRechargeMultiplier(playerId, 0.0)
     SetPlayerHealthRechargeLimit(playerId, 0.0)
     SetPedArmour(ped, playerMetadata.armor)


### PR DESCRIPTION
## Description

If player logs out with less than 200hp and logs back in, they will be back at 200hp. This change fixe this issue
It's my first contribution, first pull request and i learn developpement so sorry if my contribution is not good

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
