### PR TITLE
Replicate isDead to statebag

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -33,6 +33,7 @@ AddStateBagChangeHandler(DEATH_STATE_STATE_BAG, nil, function(bagName, _, value)
 	local player = exports.qbx_core:GetPlayer(playerId)
 	player.Functions.SetMetaData('isdead', value == sharedConfig.deathState.DEAD)
 	player.Functions.SetMetaData('inlaststand', value == sharedConfig.deathState.LAST_STAND)
+	Player(playerId).state:set("isDead", value == sharedConfig.deathState.DEAD or value == sharedConfig.deathState.LAST_STAND, true)
 end)
 
 ---@param player table|number


### PR DESCRIPTION
## Description

The isDead statebag is used by pma-voice to disable the radio. (it could also be used for other things i guess)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
