### PR TITLE
fix(client/laststand): player not always going to laststand state

### DIFF
--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -5,7 +5,7 @@ local WEAPONS = exports.qbx_core:GetWeapons()
 ---blocks until ped is no longer moving
 function WaitForPlayerToStopMoving()
     local timeOut = 10000
-    while GetEntitySpeed(cache.ped) > 0.5 or IsPedRagdoll(cache.ped) and timeOut > 1 do timeOut -= 10 Wait(10) end
+    while GetEntitySpeed(cache.ped) > 1.0 or IsPedRagdoll(cache.ped) and timeOut > 1 do timeOut -= 10 Wait(10) end
 end
 
 --- low level GTA resurrection


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Fixed the issue where the player gets stuck in the ragdoll animation and never go into the last stand state unless they're melee attacked. Tested it about 30 times, and it works.


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
