### PR TITLE
fix(client/laststand): trigger disarm event in StartLaststand

### DIFF
--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -61,6 +61,7 @@ end
 ---put player in last stand mode and notify EMS.
 function StartLastStand()
     Wait(1000)
+    TriggerEvent('ox_inventory:disarm', cache.playerId, true)
     WaitForPlayerToStopMoving()
     TriggerServerEvent('InteractSound_SV:PlayOnSource', 'demo', 0.1)
     LaststandTime = config.laststandReviveInterval


### PR DESCRIPTION
## Description

Should help with frozen ragdoll states, most cases where ragdoll state was frozen the weapon was equipped.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
