### PR TITLE
fix(client/laststand): counting down at double speed

### DIFF
--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -59,8 +59,12 @@ local function countdownLastStand()
     end
 end
 
+local startLastStandLock = false
+
 ---put player in last stand mode and notify EMS.
 function StartLastStand(attacker, weapon)
+    if startLastStandLock then return end
+    startLastStandLock = true
     TriggerEvent('ox_inventory:disarm', cache.playerId, true)
     WaitForPlayerToStopMoving()
     TriggerServerEvent('InteractSound_SV:PlayOnSource', 'demo', 0.1)
@@ -83,6 +87,7 @@ function StartLastStand(attacker, weapon)
             PlayLastStandAnimation()
             Wait(0)
         end
+        startLastStandLock = false
     end)
 end
 


### PR DESCRIPTION
StartLastStand() is invoked when the player takes damage, however waits for the player to stop moving to actually change the state bag value. Thus if the player takes further damage while rag dolling, StartLastStand() is triggered again. This results in multiple threads being created which count down the counter.

The solution in this PR is to acquire an exclusive lock so that StartLastStand() cannot be running in two separate threads.
An alternative solution would be to move the waiting for the player to stop moving to the call sites of StartLastStand() and instead of using a lock, just check the state bag value isn't already in last stand.