### PR TITLE
Update dead.lua | Fixed inventory hotkeys

### DIFF
--- a/client/dead.lua
+++ b/client/dead.lua
@@ -37,6 +37,7 @@ function OnDeath(attacker, weapon)
         end
     end)
     LocalPlayer.state.invBusy = true
+    LocalPlayer.state.invHotkeys = false
 
     ResurrectPlayer()
     playDeadAnimation()
@@ -55,6 +56,7 @@ local function respawn()
     end
     TriggerEvent('police:client:DeEscort')
     LocalPlayer.state.invBusy = false
+    LocalPlayer.state.invHotkeys = true
 end
 
 ---Allow player to respawn


### PR DESCRIPTION
Disabled the usage of inventory hotkeys using ox inventories' "LocalPlayer.state.invHotkeys = false" while the player is dead

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ x] My pull request fits the contribution guidelines & code conventions.
