### PR TITLE
Fix menu qbx_spawn menu navigation for dead and last stand players

### DIFF
--- a/client/dead.lua
+++ b/client/dead.lua
@@ -140,4 +140,10 @@ function DisableControls()
     EnableControlAction(0, 249, true)
     EnableControlAction(0, 46, true)
     EnableControlAction(0, 47, true)
+
+    -- Buttons used for navigating qbx_spawn
+    -- https://github.com/Qbox-project/qbx_spawn/blob/e129d40146ec64817c4bc55842907971b8f0e3bb/client/main.lua#L74-L76
+    EnableControlAction(0, 187, true)
+    EnableControlAction(0, 188, true)
+    EnableControlAction(0, 191, true)
 end


### PR DESCRIPTION
## Description

Fixes: https://github.com/Qbox-project/qbx_medical/issues/111

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
