### PR TITLE
fix(client): Added check for player to be logged in before being able…

### DIFF
--- a/client/dead.lua
+++ b/client/dead.lua
@@ -2,6 +2,7 @@ local config = require 'config.client'
 local sharedConfig = require 'config.shared'
 local WEAPONS = exports.qbx_core:GetWeapons()
 local allowRespawn = true
+local plyState = LocalPlayer.state
 
 local function playDeadAnimation()
     local deadAnimDict = 'dead'
@@ -39,7 +40,7 @@ function OnDeath(attacker, weapon)
             Wait(0)
         end
     end)
-    LocalPlayer.state.invBusy = true
+    plyState.invBusy = true
 
     ResurrectPlayer()
     playDeadAnimation()
@@ -57,7 +58,7 @@ local function respawn()
         TriggerEvent('police:client:GetCuffed', -1)
     end
     TriggerEvent('police:client:DeEscort')
-    LocalPlayer.state.invBusy = false
+    plyState.invBusy = false
 end
 
 ---Allow player to respawn
@@ -117,6 +118,7 @@ end
 ---@param data table
 AddEventHandler('gameEventTriggered', function(event, data)
     if event ~= 'CEventNetworkEntityDamage' then return end
+    if not plyState.isLoggedIn then return end
     local victim, attacker, victimDied, weapon = data[1], data[2], data[4], data[7]
     if not IsEntityAPed(victim) or not victimDied or NetworkGetPlayerIndexFromPed(victim) ~= cache.playerId or not IsEntityDead(cache.ped) then return end
     if DeathState == sharedConfig.deathState.ALIVE then

--- a/client/load-unload.lua
+++ b/client/load-unload.lua
@@ -1,4 +1,5 @@
 local config = require 'config.client'
+local plyState = LocalPlayer.state
 
 ---Initialize health and armor settings on the player's ped
 ---@param ped number
@@ -15,6 +16,7 @@ end
 ---starts death or last stand based off of player's metadata
 ---@param metadata any
 local function initDeathAndLastStand(metadata)
+    if not plyState.isLoggedIn then return end
     if metadata.isdead then
         DeathTime = config.deathTime
         OnDeath()


### PR DESCRIPTION
… to go in laststand/death

## Description

It fixes the issue where upon joining the server sometimes you will be set into laststand/death mode even if do not have selected a char.

## Checklist


- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
