### PR TITLE
fix: secure medical callbacks

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -167,7 +167,6 @@ local function resetAllInjuries()
     SendBleedAlert()
     MakePedLimp()
     doLimbAlert()
-    lib.callback.await('qbx_medical:server:resetHungerAndThirst')
 end
 
 ---notify the player of bleeding to their body.

--- a/server/main.lua
+++ b/server/main.lua
@@ -12,6 +12,7 @@ local logger = require '@qbx_core.modules.logger'
 ---@alias Source number
 
 local triggerEventHooks = require '@qbx_core.modules.hooks'
+local respawning = {}
 
 local function getDeathState(src)
 	local player = exports.qbx_core:GetPlayer(src)
@@ -37,11 +38,27 @@ AddStateBagChangeHandler(DEATH_STATE_STATE_BAG, nil, function(bagName, _, value)
         player.Functions.SetMetaData('isdead', value == sharedConfig.deathState.DEAD)
         player.Functions.SetMetaData('inlaststand', value == sharedConfig.deathState.LAST_STAND)
         Player(playerId).state:set("isDead", value == sharedConfig.deathState.DEAD or value == sharedConfig.deathState.LAST_STAND, true)
+        if value == sharedConfig.deathState.ALIVE then
+            respawning[playerId] = nil
+        end
     end
 end)
 
 ---@param player table|number
+local function resetHungerAndThirst(player)
+    if type(player) == 'number' then
+        player = exports.qbx_core:GetPlayer(player)
+    end
+    if not player then return end
+
+    player.Functions.SetMetaData('hunger', 100)
+    player.Functions.SetMetaData('thirst', 100)
+    TriggerClientEvent('hud:client:UpdateNeeds', player.PlayerData.source, 100, 100)
+end
+
+---@param player table|number
 local function revivePlayer(player)
+    resetHungerAndThirst(player)
     TriggerClientEvent('qbx_medical:client:playerRevived', player --[[@as number]])
 end
 
@@ -50,6 +67,7 @@ exports('Revive', revivePlayer)
 ---removes all ailments, sets to full health, and fills up hunger and thirst.
 ---@param src Source
 local function heal(src)
+    resetHungerAndThirst(src)
     TriggerClientEvent('qbx_medical:client:heal', src, 'full')
 end
 
@@ -115,23 +133,12 @@ end
 
 exports('GetPlayerStatus', getPlayerStatus)
 
----@param amount number
-lib.callback.register('qbx_medical:server:setArmor', function(source, amount)
+lib.callback.register('qbx_medical:server:setArmor', function(source)
 	local player = exports.qbx_core:GetPlayer(source)
-	player.Functions.SetMetaData('armor', amount)
+	if not player then return end
+	local armor = math.max(0, math.min(100, GetPedArmour(GetPlayerPed(source))))
+	player.Functions.SetMetaData('armor', armor)
 end)
-
-local function resetHungerAndThirst(player)
-	if type(player) == 'number' then
-		player = exports.qbx_core:GetPlayer(player)
-	end
-
-	player.Functions.SetMetaData('hunger', 100)
-	player.Functions.SetMetaData('thirst', 100)
-	TriggerClientEvent('hud:client:UpdateNeeds', player.PlayerData.source, 100, 100)
-end
-
-lib.callback.register('qbx_medical:server:resetHungerAndThirst', resetHungerAndThirst)
 
 lib.addCommand('revive', {
     help = locale('info.revive_player_a'),
@@ -182,11 +189,24 @@ lib.addCommand('aheal', {
 end)
 
 lib.callback.register('qbx_medical:server:respawn', function(source)
-	if not triggerEventHooks('respawn', {source = source}) then return false end
+	if Player(source).state[DEATH_STATE_STATE_BAG] ~= sharedConfig.deathState.DEAD or respawning[source] then return false end
+	local respawnToken = GetGameTimer()
+	respawning[source] = respawnToken
+	if not triggerEventHooks('respawn', {source = source}) then
+		respawning[source] = nil
+		return false
+	end
 	TriggerEvent('qbx_medical:server:playerRespawned', source)
+	SetTimeout(30000, function()
+		if respawning[source] == respawnToken then respawning[source] = nil end
+	end)
 	return true
 end)
 
 lib.callback.register('qbx_medical:server:log', function(_, event, message)
 	logger.log({source = 'qbx_medical', event = event, message = message})
+end)
+
+AddEventHandler('playerDropped', function()
+	respawning[source] = nil
 end)


### PR DESCRIPTION
Moves needs restoration into trusted heal/revive paths, derives armor server-side, and locks repeated respawn processing. Validation: git diff --check.